### PR TITLE
Version check bug fixed.

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -13,7 +13,7 @@ client_scripts {
 }
 
 --dont touch
-version '1.0'
+version '1.1'
 vorp_checker 'yes'
 vorp_name '^4Resource version Check^3'
 vorp_github 'https://github.com/VORPCORE/vorp_imapviewtool'


### PR DESCRIPTION
You always get the outdated print because the “version” file contains a different version.